### PR TITLE
Drop Illuminate Support as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
     "php": "^8.0",
     "ext-json": "*",
     "psr/http-message": "^1.0",
-    "doctrine/annotations": "^1.12",
-    "illuminate/support": "^7.0 || ^8.0"
+    "doctrine/annotations": "^1.12"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",

--- a/src/Converter/ModelConverter.php
+++ b/src/Converter/ModelConverter.php
@@ -8,7 +8,6 @@ use Dogado\JsonApi\Exception\DataModelSerializerException;
 use Dogado\JsonApi\Model\Resource\Resource as JsonApiResource;
 use Dogado\JsonApi\Model\Resource\ResourceInterface;
 use Dogado\JsonApi\Support\Model\DataModelAnalyser;
-use Illuminate\Support\Arr;
 use ReflectionException;
 
 class ModelConverter
@@ -25,10 +24,29 @@ class ModelConverter
         }
 
         $attributes = [];
-        foreach ($analyser->getAttributeValues() as $key => $value) {
-            Arr::set($attributes, str_replace('/', '.', $key), $value);
+        foreach ($analyser->getAttributeValues() as $keyMap => $value) {
+            $this->setNestedAttributeValue($attributes, $keyMap, $value);
         }
 
         return new JsonApiResource($analyser->getType(), $analyser->getIdValue(), $attributes);
+    }
+
+    private function setNestedAttributeValue(array &$attributes, string $keyMap, mixed $value): void
+    {
+        $keys = explode('/', $keyMap);
+        foreach ($keys as $i => $keyPart) {
+            if (1 === count($keys)) {
+                break;
+            }
+
+            unset($keys[$i]);
+
+            if (!isset($attributes[$keyPart]) || !is_array($attributes[$keyPart])) {
+                $attributes[$keyPart] = [];
+            }
+            $attributes = &$attributes[$keyPart];
+        }
+
+        $attributes[array_shift($keys)] = $value;
     }
 }

--- a/src/Support/Model/DataModelAnalyser.php
+++ b/src/Support/Model/DataModelAnalyser.php
@@ -79,7 +79,7 @@ class DataModelAnalyser
     }
 
     /**
-     * @return mixed[]
+     * @return array<string, mixed> All attribute values indexed by a slash separated key.
      */
     public function getAttributeValues(): array
     {

--- a/tests/Converter/ModelConverterTest.php
+++ b/tests/Converter/ModelConverterTest.php
@@ -2,7 +2,7 @@
 
 namespace Dogado\JsonApi\Tests\Converter;
 
-use DateTime;
+use DateTimeInterface;
 use Dogado\JsonApi\Converter\ModelConverter;
 use Dogado\JsonApi\Exception\DataModelSerializerException;
 use Dogado\JsonApi\Model\Resource\Resource;
@@ -42,7 +42,7 @@ class ModelConverterTest extends TestCase
             'empty-values' => [
                 'number' => null,
             ],
-            'createdAt' => $date->format(DateTime::ATOM),
+            'createdAt' => $date->format(DateTimeInterface::ATOM),
             'updatedAt' => null,
         ]);
 
@@ -61,7 +61,7 @@ class ModelConverterTest extends TestCase
             'empty-values' => [
                 'number' => null,
             ],
-            'createdAt' => $date->format(DateTime::ATOM),
+            'createdAt' => $date->format(DateTimeInterface::ATOM),
             'updatedAt' => null,
         ]);
 
@@ -80,7 +80,7 @@ class ModelConverterTest extends TestCase
             'empty-values' => [
                 'number' => null,
             ],
-            'createdAt' => $date->format(DateTime::ATOM),
+            'createdAt' => $date->format(DateTimeInterface::ATOM),
             'updatedAt' => null,
         ]);
 

--- a/tests/Converter/ModelConverterTest/DataModel.php
+++ b/tests/Converter/ModelConverterTest/DataModel.php
@@ -3,6 +3,7 @@
 namespace Dogado\JsonApi\Tests\Converter\ModelConverterTest;
 
 use DateTime;
+use DateTimeInterface;
 use Dogado\JsonApi\Annotations\Attribute;
 use Dogado\JsonApi\Annotations\Id;
 use Dogado\JsonApi\Annotations\Type;
@@ -63,7 +64,7 @@ class DataModel implements CustomAttributeGetterInterface, CustomAttributeSetter
     {
         switch ($property) {
             case 'createdAt':
-                return $this->createdAt->format(DateTime::ATOM);
+                return $this->createdAt->format(DateTimeInterface::ATOM);
             default:
                 return null;
         }
@@ -76,7 +77,7 @@ class DataModel implements CustomAttributeGetterInterface, CustomAttributeSetter
     {
         switch ($property) {
             case 'createdAt':
-                $dateTime = DateTime::createFromFormat(DateTime::ATOM, $value);
+                $dateTime = DateTime::createFromFormat(DateTimeInterface::ATOM, $value);
                 if (!$dateTime) {
                     throw new InvalidArgumentException('createdAt is no valid atom string');
                 }

--- a/tests/Converter/ModelConverterTest/Php8Attributes/DataModel.php
+++ b/tests/Converter/ModelConverterTest/Php8Attributes/DataModel.php
@@ -3,6 +3,7 @@
 namespace Dogado\JsonApi\Tests\Converter\ModelConverterTest\Php8Attributes;
 
 use DateTime;
+use DateTimeInterface;
 use Dogado\JsonApi\Annotations\Attribute;
 use Dogado\JsonApi\Annotations\Id;
 use Dogado\JsonApi\Annotations\Type;
@@ -47,7 +48,7 @@ class DataModel implements CustomAttributeGetterInterface, CustomAttributeSetter
     {
         switch ($property) {
             case 'createdAt':
-                return $this->createdAt->format(DateTime::ATOM);
+                return $this->createdAt->format(DateTimeInterface::ATOM);
             default:
                 return null;
         }
@@ -60,7 +61,7 @@ class DataModel implements CustomAttributeGetterInterface, CustomAttributeSetter
     {
         switch ($property) {
             case 'createdAt':
-                $dateTime = DateTime::createFromFormat(DateTime::ATOM, $value);
+                $dateTime = DateTime::createFromFormat(DateTimeInterface::ATOM, $value);
                 if (!$dateTime) {
                     throw new InvalidArgumentException('createdAt is no valid atom string');
                 }

--- a/tests/Converter/ModelConverterTest/Php8Attributes/DataModelWithMixedAnnotations.php
+++ b/tests/Converter/ModelConverterTest/Php8Attributes/DataModelWithMixedAnnotations.php
@@ -3,6 +3,7 @@
 namespace Dogado\JsonApi\Tests\Converter\ModelConverterTest\Php8Attributes;
 
 use DateTime;
+use DateTimeInterface;
 use Dogado\JsonApi\Annotations\Attribute;
 use Dogado\JsonApi\Annotations\Id;
 use Dogado\JsonApi\Annotations\Type;
@@ -53,7 +54,7 @@ class DataModelWithMixedAnnotations implements CustomAttributeGetterInterface, C
     {
         switch ($property) {
             case 'createdAt':
-                return $this->createdAt->format(DateTime::ATOM);
+                return $this->createdAt->format(DateTimeInterface::ATOM);
             default:
                 return null;
         }
@@ -66,7 +67,7 @@ class DataModelWithMixedAnnotations implements CustomAttributeGetterInterface, C
     {
         switch ($property) {
             case 'createdAt':
-                $dateTime = DateTime::createFromFormat(DateTime::ATOM, $value);
+                $dateTime = DateTime::createFromFormat(DateTimeInterface::ATOM, $value);
                 if (!$dateTime) {
                     throw new InvalidArgumentException('createdAt is no valid atom string');
                 }

--- a/tests/Converter/ResourceConverterTest.php
+++ b/tests/Converter/ResourceConverterTest.php
@@ -2,7 +2,7 @@
 
 namespace Dogado\JsonApi\Tests\Converter;
 
-use DateTime;
+use DateTimeInterface;
 use Dogado\JsonApi\Converter\ResourceConverter;
 use Dogado\JsonApi\Exception\DataModelSerializerException;
 use Dogado\JsonApi\Model\Resource\Resource;
@@ -52,7 +52,7 @@ class ResourceConverterTest extends TestCase
                 ],
                 'willBeCastedToArray' => $this->faker()->userName,
                 'ignoreOnNull' => $this->faker()->text,
-                'createdAt' => $date->format(DateTime::ATOM),
+                'createdAt' => $date->format(DateTimeInterface::ATOM),
                 'updatedAt' => null,
             ],
         );

--- a/tests/Converter/ResourceConverterTest/DataModel.php
+++ b/tests/Converter/ResourceConverterTest/DataModel.php
@@ -3,6 +3,7 @@
 namespace Dogado\JsonApi\Tests\Converter\ResourceConverterTest;
 
 use DateTime;
+use DateTimeInterface;
 use Dogado\JsonApi\Annotations\Attribute;
 use Dogado\JsonApi\Annotations\Id;
 use Dogado\JsonApi\Annotations\Type;
@@ -122,7 +123,7 @@ class DataModel implements CustomAttributeSetterInterface
     {
         switch ($property) {
             case 'createdAt':
-                $dateTime = DateTime::createFromFormat(DateTime::ATOM, $value);
+                $dateTime = DateTime::createFromFormat(DateTimeInterface::ATOM, $value);
                 if (!$dateTime) {
                     throw new InvalidArgumentException('createdAt value is no valid atom string');
                 }

--- a/tests/Model/Request/RequestTest.php
+++ b/tests/Model/Request/RequestTest.php
@@ -240,7 +240,7 @@ class RequestTest extends TestCase
         $paginationValue = $this->faker->numberBetween();
         $request->pagination()->set($paginationKey, $paginationValue);
 
-        $includes = $this->faker->words;
+        $includes = array_unique($this->faker->words());
         foreach ($includes as $include) {
             self::assertFalse($request->requestsInclude($include));
             $request->include($include);

--- a/tests/Support/Model/DataModelAnalyserTest.php
+++ b/tests/Support/Model/DataModelAnalyserTest.php
@@ -2,7 +2,7 @@
 
 namespace Dogado\JsonApi\Tests\Support\Model;
 
-use DateTime;
+use DateTimeInterface;
 use Dogado\JsonApi\Support\Model\DataModelAnalyser;
 use Dogado\JsonApi\Tests\Support\Model\DataModelAnalyserTest\DummyModel;
 use Dogado\JsonApi\Tests\Support\Model\DataModelAnalyserTest\ModelWithNoId;
@@ -26,7 +26,7 @@ class DataModelAnalyserTest extends TestCase
             'name' => 'newName',
             'sub-object/test/property' => 'lorem',
             'sub-object/test/second-property' => 'ipsum',
-            'sub-object/createdAt' => $date->format(DateTime::ATOM),
+            'sub-object/createdAt' => $date->format(DateTimeInterface::ATOM),
             'sub-object/updatedAt' => null,
             'sub-model/name' => 'sub-name',
             'sub-model/sub-model2/name' => 'sub-sub-name',

--- a/tests/Support/Model/DataModelAnalyserTest/DummyModel.php
+++ b/tests/Support/Model/DataModelAnalyserTest/DummyModel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Dogado\JsonApi\Tests\Support\Model\DataModelAnalyserTest;
 
 use DateTime;
+use DateTimeInterface;
 use Dogado\JsonApi\Annotations\Attribute;
 use Dogado\JsonApi\Annotations\Id;
 use Dogado\JsonApi\Annotations\Type;
@@ -78,7 +79,7 @@ class DummyModel implements CustomAttributeGetterInterface
     {
         switch ($propertyName) {
             case 'createdAt':
-                return $this->createdAt->format(DateTime::ATOM);
+                return $this->createdAt->format(DateTimeInterface::ATOM);
             default:
                 return null;
         }


### PR DESCRIPTION
Since `illuminate/support` has a lot of dependencies and we only use it for array helpers, this PR replaces the used array functions with native php code and removes the package as dependency.