### PR TITLE
[1.x] Introduce dedicated attribute classes and deprecate annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.1.2 - 2021-07-XX
+
+- introduce dedicated php 8 attribute classes to replace annotations in the next major release
+- trigger deprecation errors when using annotations
+
 ## v1.1.1 - 2021-07-04
 
 - remove `illuminate/support` as dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.1.2 - 2021-07-XX
+## v1.2.0 - 2021-07-XX
 
 - introduce dedicated php 8 attribute classes to replace annotations in the next major release
 - trigger deprecation errors when using annotations

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "php": "^8.0",
     "ext-json": "*",
     "psr/http-message": "^1.0",
-    "doctrine/annotations": "^1.12"
+    "doctrine/annotations": "^1.12",
+    "symfony/deprecation-contracts": "^2.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",

--- a/src/Annotations/Attribute.php
+++ b/src/Annotations/Attribute.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Annotation
  * @Target({"PROPERTY"})
  * @NamedArgumentConstructor()
+ * @deprecated Use the php 8 attribute Dogado\JsonApi\Attribute\Attribute instead.
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
 class Attribute

--- a/src/Annotations/Id.php
+++ b/src/Annotations/Id.php
@@ -7,6 +7,7 @@ namespace Dogado\JsonApi\Annotations;
 /**
  * @Annotation
  * @Target({"PROPERTY"})
+ * @deprecated Use the php 8 attribute Dogado\JsonApi\Attribute\Id instead.
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
 class Id

--- a/src/Annotations/Type.php
+++ b/src/Annotations/Type.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Annotation
  * @Target({"CLASS"})
  * @NamedArgumentConstructor()
+ * @deprecated Use the php 8 attribute Dogado\JsonApi\Attribute\Type instead.
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class Type

--- a/src/Attribute/Attribute.php
+++ b/src/Attribute/Attribute.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dogado\JsonApi\Attribute;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Attribute extends \Dogado\JsonApi\Annotations\Attribute
+{
+
+}

--- a/src/Attribute/Id.php
+++ b/src/Attribute/Id.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dogado\JsonApi\Attribute;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Id extends \Dogado\JsonApi\Annotations\Id
+{
+
+}

--- a/src/Attribute/Type.php
+++ b/src/Attribute/Type.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dogado\JsonApi\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class Type extends \Dogado\JsonApi\Annotations\Type
+{
+
+}

--- a/src/Support/Model/DataModelAnalyser.php
+++ b/src/Support/Model/DataModelAnalyser.php
@@ -104,6 +104,15 @@ class DataModelAnalyser
 
         foreach ($this->annotationReader->getClassAnnotations($reflection) as $annotation) {
             if ($annotation instanceof Type) {
+                trigger_deprecation(
+                    'dogado/json-api-common',
+                    '1.1',
+                    'Using the doctrine annotation "%s" in class "%s" is deprecated. Use "%s" as php 8 ' .
+                        'attribute instead.',
+                    get_class($annotation),
+                    $this->className,
+                    \Dogado\JsonApi\Attribute\Type::class
+                );
                 $this->type = $annotation->value;
             }
         }
@@ -137,6 +146,18 @@ class DataModelAnalyser
             return;
         }
 
+        if (!$annotation instanceof \Dogado\JsonApi\Attribute\Id) {
+            trigger_deprecation(
+                'dogado/json-api-common',
+                '1.1',
+                'Using the doctrine annotation "%s" in class "%s" is deprecated. Use "%s" as php 8 ' .
+                'attribute instead.',
+                get_class($annotation),
+                $this->className,
+                \Dogado\JsonApi\Attribute\Id::class
+            );
+        }
+
         $this->propertyMap['id'] = $property->getName();
         if (null === $this->model) {
             $this->resourceValueMap['id'] = null;
@@ -158,6 +179,18 @@ class DataModelAnalyser
     ): void {
         if (!$annotation instanceof Attribute) {
             return;
+        }
+
+        if (!$annotation instanceof \Dogado\JsonApi\Attribute\Attribute) {
+            trigger_deprecation(
+                'dogado/json-api-common',
+                '1.1',
+                'Using the doctrine annotation "%s" in class "%s" is deprecated. Use "%s" as php 8 ' .
+                'attribute instead.',
+                get_class($annotation),
+                $this->className,
+                \Dogado\JsonApi\Attribute\Attribute::class
+            );
         }
 
         $attributeName = trim($attributeNamePrefix . '/' . ($annotation->value ?? $property->getName()));

--- a/src/Support/Model/DataModelAnalyser.php
+++ b/src/Support/Model/DataModelAnalyser.php
@@ -106,7 +106,7 @@ class DataModelAnalyser
             if ($annotation instanceof Type) {
                 trigger_deprecation(
                     'dogado/json-api-common',
-                    '1.1',
+                    '1.2',
                     'Using the doctrine annotation "%s" in class "%s" is deprecated. Use "%s" as php 8 ' .
                         'attribute instead.',
                     get_class($annotation),
@@ -149,7 +149,7 @@ class DataModelAnalyser
         if (!$annotation instanceof \Dogado\JsonApi\Attribute\Id) {
             trigger_deprecation(
                 'dogado/json-api-common',
-                '1.1',
+                '1.2',
                 'Using the doctrine annotation "%s" in class "%s" is deprecated. Use "%s" as php 8 ' .
                 'attribute instead.',
                 get_class($annotation),
@@ -184,7 +184,7 @@ class DataModelAnalyser
         if (!$annotation instanceof \Dogado\JsonApi\Attribute\Attribute) {
             trigger_deprecation(
                 'dogado/json-api-common',
-                '1.1',
+                '1.2',
                 'Using the doctrine annotation "%s" in class "%s" is deprecated. Use "%s" as php 8 ' .
                 'attribute instead.',
                 get_class($annotation),

--- a/tests/Converter/ModelConverterTest/Php8Attributes/DataModel.php
+++ b/tests/Converter/ModelConverterTest/Php8Attributes/DataModel.php
@@ -4,9 +4,9 @@ namespace Dogado\JsonApi\Tests\Converter\ModelConverterTest\Php8Attributes;
 
 use DateTime;
 use DateTimeInterface;
-use Dogado\JsonApi\Annotations\Attribute;
-use Dogado\JsonApi\Annotations\Id;
-use Dogado\JsonApi\Annotations\Type;
+use Dogado\JsonApi\Attribute\Attribute;
+use Dogado\JsonApi\Attribute\Id;
+use Dogado\JsonApi\Attribute\Type;
 use Dogado\JsonApi\Support\Model\CustomAttributeGetterInterface;
 use Dogado\JsonApi\Support\Model\CustomAttributeSetterInterface;
 use InvalidArgumentException;

--- a/tests/Converter/ModelConverterTest/Php8Attributes/DataModelWithoutTypeAnnotation.php
+++ b/tests/Converter/ModelConverterTest/Php8Attributes/DataModelWithoutTypeAnnotation.php
@@ -2,7 +2,7 @@
 
 namespace Dogado\JsonApi\Tests\Converter\ModelConverterTest\Php8Attributes;
 
-use Dogado\JsonApi\Annotations\Id;
+use Dogado\JsonApi\Attribute\Id;
 
 class DataModelWithoutTypeAnnotation
 {

--- a/tests/Converter/ModelConverterTest/Php8Attributes/ValueObject.php
+++ b/tests/Converter/ModelConverterTest/Php8Attributes/ValueObject.php
@@ -2,7 +2,7 @@
 
 namespace Dogado\JsonApi\Tests\Converter\ModelConverterTest\Php8Attributes;
 
-use Dogado\JsonApi\Annotations\Attribute;
+use Dogado\JsonApi\Attribute\Attribute;
 
 class ValueObject
 {


### PR DESCRIPTION
Closes #7.

I'm not really sure about the naming of the namespace `Dogado\JsonApi\Attribute`. We could also name it `Attributes`, but I tend to `Attribute\[...]`.