### PR TITLE
Add support for `mixed` data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - introduce dedicated php 8 attribute classes to replace annotations in the next major release
 - trigger deprecation errors when using annotations
+- add support for the `mixed` data type within the `ResourceConverter`
 
 ## v1.1.1 - 2021-07-04
 

--- a/docs/08-models.md
+++ b/docs/08-models.md
@@ -156,14 +156,14 @@ class User
 
 ## Typed properties
 
-This package supports php `7.4`, which means that it also supports typed properties, and a limited casting of values. Casting will be done for the following property data types:
+This package supports php `8.0`, which means that it also supports typed properties, and a limited casting of values. Casting will be done for the following property data types:
 * `bool`/`boolean`
 * `int`/`integer`
 * `float`
 * `string`
 * `array`
 
-Other data types will be ignored.
+`mixed` values are kept and all other types will be ignored.
 
 It is highly recommended to use typed properties as much as possible, and it is good practice to also make them nullable, since the remote JSON API server might not return some attributes that your data model expects. Otherwise, this will end in a php fatal error.
 

--- a/src/Converter/ResourceConverter.php
+++ b/src/Converter/ResourceConverter.php
@@ -83,7 +83,11 @@ class ResourceConverter
             return;
         }
 
-        if (null === $property->getType() || $property->getType()->getName() === gettype($value)) {
+        if (
+            null === $property->getType() ||
+            'mixed' === $property->getType()->getName() ||
+            $property->getType()->getName() === gettype($value)
+        ) {
             $property->setAccessible(true);
             $property->setValue($model, $value);
             return;

--- a/tests/Converter/ResourceConverterTest.php
+++ b/tests/Converter/ResourceConverterTest.php
@@ -22,7 +22,7 @@ class ResourceConverterTest extends TestCase
     {
         $type = 'dummy-deserializer-model';
         $faker = $this->faker();
-        $date = $this->faker()->dateTime;
+        $date = $this->faker()->dateTime();
         $resource = new Resource(
             $type,
             (string) $this->faker()->numberBetween(),

--- a/tests/Converter/ResourceConverterTest.php
+++ b/tests/Converter/ResourceConverterTest.php
@@ -21,12 +21,18 @@ class ResourceConverterTest extends TestCase
     public function testResourceToModel(): void
     {
         $type = 'dummy-deserializer-model';
+        $faker = $this->faker();
         $date = $this->faker()->dateTime;
         $resource = new Resource(
             $type,
             (string) $this->faker()->numberBetween(),
             [
                 'stringValue' => $this->faker()->userName,
+                'mixedValue' => $this->faker()->randomElement([
+                    $faker->slug(),
+                    $faker->boolean(),
+                    $faker->numberBetween()
+                ]),
                 'doesNotExistInModel' => $this->faker()->userName,
                 'noTypeDeclaration' => $this->faker()->userName,
                 'notNullable' => $this->faker()->userName,
@@ -63,6 +69,8 @@ class ResourceConverterTest extends TestCase
 
         $this->assertEquals($resource->id(), $model->getId());
         $this->assertNull($model->getNullAttribute());
+        $this->assertEquals($attributes->getRequired('stringValue'), $model->getStringValue());
+        $this->assertEquals($attributes->getRequired('mixedValue'), $model->getMixedValue());
         $this->assertEquals($attributes->getRequired('noTypeDeclaration'), $model->getNoTypeDeclaration());
         $this->assertEquals($attributes->getRequired('notNullable'), $model->getNotNullable());
         $this->assertNull($model->getDoesNotExistInResource());

--- a/tests/Converter/ResourceConverterTest/DataModel.php
+++ b/tests/Converter/ResourceConverterTest/DataModel.php
@@ -32,6 +32,11 @@ class DataModel implements CustomAttributeSetterInterface
 
     /**
      * @Attribute()
+     */
+    private mixed $mixedValue = null;
+
+    /**
+     * @Attribute()
      * @var mixed
      */
     private $noTypeDeclaration;
@@ -147,6 +152,11 @@ class DataModel implements CustomAttributeSetterInterface
     public function getStringValue(): ?string
     {
         return $this->stringValue;
+    }
+
+    public function getMixedValue(): mixed
+    {
+        return $this->mixedValue;
     }
 
     /**


### PR DESCRIPTION
The php data type `mixed` is currently not supported in the `ResourceConverter`.