### PR TITLE
Add a way to fetch the original attributes payload when handling converted models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.0 - 2022-04-XX
+
+- Resource converter: Add `Dogado\JsonApi\Support\Model\PlainAttributesInterface` to optionally be able to fetch the original attributes input in model instances
+
 ## v3.0.0 - 2021-10-01
 
 - Request: Add ability to add custom query parameters to requests

--- a/src/Attribute/Id.php
+++ b/src/Attribute/Id.php
@@ -7,5 +7,4 @@ namespace Dogado\JsonApi\Attribute;
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
 class Id
 {
-
 }

--- a/src/Converter/ResourceConverter.php
+++ b/src/Converter/ResourceConverter.php
@@ -8,6 +8,7 @@ use Dogado\JsonApi\Exception\DataModelSerializerException;
 use Dogado\JsonApi\Model\Resource\ResourceInterface;
 use Dogado\JsonApi\Support\Model\CustomAttributeSetterInterface;
 use Dogado\JsonApi\Support\Model\DataModelAnalyser;
+use Dogado\JsonApi\Support\Model\PlainAttributesInterface;
 use Dogado\JsonApi\Support\Model\ValueObjectFactoryInterface;
 use ReflectionClass;
 use ReflectionException;
@@ -48,6 +49,10 @@ class ResourceConverter
         }
 
         $attributeValues = $resource->attributes()->all();
+        if ($model instanceof PlainAttributesInterface) {
+            $model->setPlainAttributes($resource->attributes());
+        }
+
         foreach ($analyser->getAttributesPropertyMap() as $attributeMap => $propertyMap) {
             $this->setValue(
                 $reflection,

--- a/src/Support/Model/PlainAttributesInterface.php
+++ b/src/Support/Model/PlainAttributesInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dogado\JsonApi\Support\Model;
+
+use Dogado\JsonApi\Support\Collection\KeyValueCollectionInterface;
+
+interface PlainAttributesInterface
+{
+    public function getPlainAttributes(): KeyValueCollectionInterface;
+
+    public function setPlainAttributes(KeyValueCollectionInterface $attributes): self;
+}

--- a/src/Support/Model/PlainAttributesTrait.php
+++ b/src/Support/Model/PlainAttributesTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dogado\JsonApi\Support\Model;
+
+use Dogado\JsonApi\Support\Collection\KeyValueCollection;
+use Dogado\JsonApi\Support\Collection\KeyValueCollectionInterface;
+
+trait PlainAttributesTrait
+{
+    private ?KeyValueCollectionInterface $plainAttributes = null;
+
+    public function setPlainAttributes(KeyValueCollectionInterface $attributes): self
+    {
+        $this->plainAttributes = $attributes;
+        return $this;
+    }
+
+    public function getPlainAttributes(): KeyValueCollectionInterface
+    {
+        return $this->plainAttributes ?? new KeyValueCollection();
+    }
+}

--- a/tests/Converter/ResourceConverterTest/DataModelWithPlainAttributes.php
+++ b/tests/Converter/ResourceConverterTest/DataModelWithPlainAttributes.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Dogado\JsonApi\Tests\Converter\ResourceConverterTest;
+
+use Dogado\JsonApi\Attribute\Type;
+use Dogado\JsonApi\Support\Model\PlainAttributesInterface;
+use Dogado\JsonApi\Support\Model\PlainAttributesTrait;
+
+#[Type('dummy-deserializer-model-with-plain-attributes')]
+class DataModelWithPlainAttributes implements PlainAttributesInterface
+{
+    use PlainAttributesTrait;
+}


### PR DESCRIPTION
This pull request adds an optional `Dogado\JsonApi\Support\Model\PlainAttributesInterface` that can be implemented for models, so that one is able to fetch the original attribute payload. This will solve #21.